### PR TITLE
Use memfd_create on GNU systems and swap mmap order in allocator for IMA

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,10 @@ fn main() {
     } else {
         cc.define("SLJIT_PROT_EXECUTABLE_ALLOCATOR", "1");
     }
+    if env::var("TARGET").unwrap().contains("gnu") {
+        cc.define("_GNU_SOURCE", "1");
+        cc.define("HAVE_MEMFD_CREATE", "1");
+    }
     cc.define("SLJIT_ARGUMENT_CHECKS", "1");
     cc.define("SLJIT_DEBUG", "0");
     cc.define("SLJIT_VERBOSE", "0");


### PR DESCRIPTION
This uses memfd_create on GNU systems instead of unnamed temp files.  This additionally reorders the mmap operations in the allocator to work around the Linux Integrity Measurement System from blocking allocations.